### PR TITLE
Add linter and formatter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,32 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    sourceType: 'module',
+  },
+  plugins: [
+    '@typescript-eslint/eslint-plugin',
+    'unused-imports',
+    'deprecation',
+  ],
+  extends: [
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/await-thenable': 'error',
+    'deprecation/deprecation': 'error',
+    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars-experimental': 'error',
+  },
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": false
+}

--- a/components/button/button.tsx
+++ b/components/button/button.tsx
@@ -1,69 +1,69 @@
-import classNames from "classnames";
-import { MouseEventHandler, PropsWithChildren } from "react";
+import classNames from 'classnames'
+import { FunctionComponent, MouseEventHandler } from 'react'
 
 type IProps = {
-  href?: string;
-  onClick?: MouseEventHandler<any>;
-  outlined?: boolean;
-  shadow?: boolean;
-  icon?: any;
-  large?: boolean;
-  text?: boolean;
-  className?: string;
-};
+  href?: string
+  onClick?: MouseEventHandler<any>
+  outlined?: boolean
+  shadow?: boolean
+  icon?: any
+  large?: boolean
+  text?: boolean
+  className?: string
+}
 
-export default function Button(props: PropsWithChildren<IProps>) {
+const Button: FunctionComponent<IProps> = (props) => {
   const structure =
-    "whitespace-nowrap inline-flex items-center justify-center rounded-full text-base";
+    'whitespace-nowrap inline-flex items-center justify-center rounded-full text-base'
   const px = props.text
-    ? ""
+    ? ''
     : props.large
     ? props.children
-      ? "px-6"
-      : "px-3"
+      ? 'px-6'
+      : 'px-3'
     : props.children
-    ? "px-4"
-    : "px-2";
-  const py = props.large ? "py-3" : "py-2";
-  const size = `${px} ${py}`;
+    ? 'px-4'
+    : 'px-2'
+  const py = props.large ? 'py-3' : 'py-2'
+  const size = `${px} ${py}`
   const border = props.outlined
-    ? "border border-purple-300 ring-1 ring-black ring-opacity-5"
+    ? 'border border-purple-300 ring-1 ring-black ring-opacity-5'
     : props.text
-    ? ""
-    : "ring-1 ring-black ring-opacity-5";
+    ? ''
+    : 'ring-1 ring-black ring-opacity-5'
   const color = props.outlined
-    ? "text-purple-900 bg-white"
+    ? 'text-purple-900 bg-white'
     : props.text
-    ? "text-primary"
-    : "text-white bg-gradient-to-r from-primary to-secondary";
-  const shadow = props.shadow && !props.text ? "shadow-xl" : null;
-  const iconMargin = props.children ? "mr-3" : "";
+    ? 'text-primary'
+    : 'text-white bg-gradient-to-r from-primary to-secondary'
+  const shadow = props.shadow && !props.text ? 'shadow-xl' : null
+  const iconMargin = props.children ? 'mr-3' : ''
   const icon = props.text
     ? classNames(
-        "rounded-full text-white bg-gradient-to-r from-primary to-secondary h-10 w-10 p-2 ring-1 ring-black ring-opacity-5",
-        props.shadow ? "shadow-xl" : null
+        'rounded-full text-white bg-gradient-to-r from-primary to-secondary h-10 w-10 p-2 ring-1 ring-black ring-opacity-5',
+        props.shadow ? 'shadow-xl' : null,
       )
-    : "";
-  const iconSize = props.text ? "" : "h-4 w-4";
+    : ''
+  const iconSize = props.text ? '' : 'h-4 w-4'
   return (
     <a
-      href={"href" in props ? props.href : "#"}
-      onClick={"onClick" in props ? props.onClick : null}
+      href={'href' in props ? props.href : '#'}
+      onClick={'onClick' in props ? props.onClick : null}
       className={classNames(
         structure,
         size,
         border,
         color,
         shadow,
-        props.className
+        props.className,
       )}
     >
       {props.icon && (
         <div
           className={classNames(
-            "flex justify-center align-middle",
+            'flex justify-center align-middle',
             icon,
-            iconMargin
+            iconMargin,
           )}
         >
           <props.icon className={classNames(iconSize)} aria-hidden="true" />
@@ -71,5 +71,7 @@ export default function Button(props: PropsWithChildren<IProps>) {
       )}
       {props.children}
     </a>
-  );
+  )
 }
+
+export default Button

--- a/components/container/container-with-background.tsx
+++ b/components/container/container-with-background.tsx
@@ -1,23 +1,23 @@
-import classNames from "classnames";
-import { PropsWithChildren } from "react";
+import classNames from 'classnames'
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function ContainerWithBackground(
-  props: PropsWithChildren<IProps>
-) {
+const ContainerWithBackground: FunctionComponent<IProps> = (props) => {
   return (
     <div
       className={classNames(
-        "relative mx-auto max-w-7xl xl:rounded-2xl bg-gradient-to-r from-purple-100 to-purple-50 p-6 sm:p-12 lg:p-24",
-        props.className
+        'relative mx-auto max-w-7xl xl:rounded-2xl bg-gradient-to-r from-purple-100 to-purple-50 p-6 sm:p-12 lg:p-24',
+        props.className,
       )}
     >
       <div className="rounded-2xl px-6 py-10 bg-white overflow-hidden shadow-xl sm:px-12 sm:py-12 sm:text-center">
         {props.children}
       </div>
     </div>
-  );
+  )
 }
+
+export default ContainerWithBackground

--- a/components/container/container.tsx
+++ b/components/container/container.tsx
@@ -1,21 +1,23 @@
-import classNames from "classnames";
-import { PropsWithChildren } from "react";
+import classNames from 'classnames'
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-  id?: string;
-};
+  className?: string
+  id?: string
+}
 
-export default function Container(props: PropsWithChildren<IProps>) {
+const Container: FunctionComponent<IProps> = (props) => {
   return (
     <div
       id={props.id}
       className={classNames(
-        "relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24",
-        props.className
+        'relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24',
+        props.className,
       )}
     >
       {props.children}
     </div>
-  );
+  )
 }
+
+export default Container

--- a/components/icon/analyse.tsx
+++ b/components/icon/analyse.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconAnalyse(props: PropsWithChildren<IProps>) {
+const IconAnalyse: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -25,5 +25,7 @@ export default function IconAnalyse(props: PropsWithChildren<IProps>) {
         fill="#231B5C"
       />
     </svg>
-  );
+  )
 }
+
+export default IconAnalyse

--- a/components/icon/arrow-large.tsx
+++ b/components/icon/arrow-large.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconArrowLarge(props: PropsWithChildren<IProps>) {
+const IconArrowLarge: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -34,5 +34,7 @@ export default function IconArrowLarge(props: PropsWithChildren<IProps>) {
         </linearGradient>
       </defs>
     </svg>
-  );
+  )
 }
+
+export default IconArrowLarge

--- a/components/icon/arrow-small.tsx
+++ b/components/icon/arrow-small.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconArrowSmall(props: PropsWithChildren<IProps>) {
+const IconArrowSmall: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -21,5 +21,7 @@ export default function IconArrowSmall(props: PropsWithChildren<IProps>) {
         fill="#D7D1FE"
       />
     </svg>
-  );
+  )
 }
+
+export default IconArrowSmall

--- a/components/icon/crypto/BTC.tsx
+++ b/components/icon/crypto/BTC.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconCryptoBtc(props: PropsWithChildren<IProps>) {
+const IconCryptoBtc: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -36,5 +36,7 @@ export default function IconCryptoBtc(props: PropsWithChildren<IProps>) {
         </linearGradient>
       </defs>
     </svg>
-  );
+  )
 }
+
+export default IconCryptoBtc

--- a/components/icon/crypto/ETH.tsx
+++ b/components/icon/crypto/ETH.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconCryptoEth(props: PropsWithChildren<IProps>) {
+const IconCryptoEth: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -46,5 +46,7 @@ export default function IconCryptoEth(props: PropsWithChildren<IProps>) {
         fill="#F3F4F6"
       />
     </svg>
-  );
+  )
 }
+
+export default IconCryptoEth

--- a/components/icon/idao.tsx
+++ b/components/icon/idao.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconIDAO(props: PropsWithChildren<IProps>) {
+const IconIDAO: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -23,5 +23,7 @@ export default function IconIDAO(props: PropsWithChildren<IProps>) {
         fill="#5540DB"
       />
     </svg>
-  );
+  )
 }
+
+export default IconIDAO

--- a/components/icon/lending.tsx
+++ b/components/icon/lending.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconLending(props: PropsWithChildren<IProps>) {
+const IconLending: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -23,5 +23,7 @@ export default function IconLending(props: PropsWithChildren<IProps>) {
         fill="#5540DB"
       />
     </svg>
-  );
+  )
 }
+
+export default IconLending

--- a/components/icon/social/discord.tsx
+++ b/components/icon/social/discord.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconSocialDiscord(props: PropsWithChildren<IProps>) {
+const IconSocialDiscord: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -19,5 +19,7 @@ export default function IconSocialDiscord(props: PropsWithChildren<IProps>) {
         fill="currentColor"
       />
     </svg>
-  );
+  )
 }
+
+export default IconSocialDiscord

--- a/components/icon/social/facebook.tsx
+++ b/components/icon/social/facebook.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconSocialFacebook(props: PropsWithChildren<IProps>) {
+const IconSocialFacebook: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -19,5 +19,7 @@ export default function IconSocialFacebook(props: PropsWithChildren<IProps>) {
         fill="#231B5C"
       />
     </svg>
-  );
+  )
 }
+
+export default IconSocialFacebook

--- a/components/icon/social/github.tsx
+++ b/components/icon/social/github.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconSocialGithub(props: PropsWithChildren<IProps>) {
+const IconSocialGithub: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -19,5 +19,7 @@ export default function IconSocialGithub(props: PropsWithChildren<IProps>) {
         fill="currentColor"
       />
     </svg>
-  );
+  )
 }
+
+export default IconSocialGithub

--- a/components/icon/social/medium.tsx
+++ b/components/icon/social/medium.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconSocialMedium(props: PropsWithChildren<IProps>) {
+const IconSocialMedium: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -31,5 +31,7 @@ export default function IconSocialMedium(props: PropsWithChildren<IProps>) {
         </clipPath>
       </defs>
     </svg>
-  );
+  )
 }
+
+export default IconSocialMedium

--- a/components/icon/social/telegram.tsx
+++ b/components/icon/social/telegram.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconSocialTelegram(props: PropsWithChildren<IProps>) {
+const IconSocialTelegram: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -19,5 +19,7 @@ export default function IconSocialTelegram(props: PropsWithChildren<IProps>) {
         fill="currentColor"
       />
     </svg>
-  );
+  )
 }
+
+export default IconSocialTelegram

--- a/components/icon/social/twitter.tsx
+++ b/components/icon/social/twitter.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconSocialTwitter(props: PropsWithChildren<IProps>) {
+const IconSocialTwitter: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -19,5 +19,7 @@ export default function IconSocialTwitter(props: PropsWithChildren<IProps>) {
         fill="currentColor"
       />
     </svg>
-  );
+  )
 }
+
+export default IconSocialTwitter

--- a/components/icon/trend/down.tsx
+++ b/components/icon/trend/down.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconTrendDown(props: PropsWithChildren<IProps>) {
+const IconTrendDown: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -19,5 +19,7 @@ export default function IconTrendDown(props: PropsWithChildren<IProps>) {
         fill="#EF4444"
       />
     </svg>
-  );
+  )
 }
+
+export default IconTrendDown

--- a/components/icon/trend/stable.tsx
+++ b/components/icon/trend/stable.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconTrendStable(props: PropsWithChildren<IProps>) {
+const IconTrendStable: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -19,5 +19,7 @@ export default function IconTrendStable(props: PropsWithChildren<IProps>) {
         fill="#0EA5E9"
       />
     </svg>
-  );
+  )
 }
+
+export default IconTrendStable

--- a/components/icon/trend/up.tsx
+++ b/components/icon/trend/up.tsx
@@ -1,10 +1,10 @@
-import { PropsWithChildren } from "react";
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function IconTrendUp(props: PropsWithChildren<IProps>) {
+const IconTrendUp: FunctionComponent<IProps> = (props) => {
   return (
     <svg
       className={props.className}
@@ -19,5 +19,7 @@ export default function IconTrendUp(props: PropsWithChildren<IProps>) {
         fill="#10B981"
       />
     </svg>
-  );
+  )
 }
+
+export default IconTrendUp

--- a/components/layouts/footer/footer.tsx
+++ b/components/layouts/footer/footer.tsx
@@ -1,56 +1,57 @@
-import Button from "../../button/button";
-import ContainerWithBackground from "../../container/container-with-background";
-import IconSocialDiscord from "../../icon/social/discord";
-import IconSocialFacebook from "../../icon/social/facebook";
-import IconSocialGithub from "../../icon/social/github";
-import IconSocialMedium from "../../icon/social/medium";
-import IconSocialTelegram from "../../icon/social/telegram";
-import IconSocialTwitter from "../../icon/social/twitter";
-import Body2 from "../../text/body2";
-import Headline from "../../text/headline";
-import Title from "../../text/title";
+import { FunctionComponent } from 'react'
+import Button from '../../button/button'
+import ContainerWithBackground from '../../container/container-with-background'
+import IconSocialDiscord from '../../icon/social/discord'
+import IconSocialFacebook from '../../icon/social/facebook'
+import IconSocialGithub from '../../icon/social/github'
+import IconSocialMedium from '../../icon/social/medium'
+import IconSocialTelegram from '../../icon/social/telegram'
+import IconSocialTwitter from '../../icon/social/twitter'
+import Body2 from '../../text/body2'
+import Headline from '../../text/headline'
+import Title from '../../text/title'
 
 const links = [
   {
-    name: "Discord",
+    name: 'Discord',
     icon: IconSocialDiscord,
-    href: "https://discord.com/invite/jqemf5XRMj",
+    href: 'https://discord.com/invite/jqemf5XRMj',
   },
   {
-    name: "Telegram",
+    name: 'Telegram',
     icon: IconSocialTelegram,
-    href: "https://t.me/quiveridaochat",
+    href: 'https://t.me/quiveridaochat',
   },
   {
-    name: "Twitter",
+    name: 'Twitter',
     icon: IconSocialTwitter,
-    href: "https://twitter.com/QuiverProtocol",
+    href: 'https://twitter.com/QuiverProtocol',
   },
   {
-    name: "Facebook",
+    name: 'Facebook',
     icon: IconSocialFacebook,
-    href: "https://www.facebook.com/Quiver-Protocol-106899561569141",
+    href: 'https://www.facebook.com/Quiver-Protocol-106899561569141',
   },
   {
-    name: "Medium",
+    name: 'Medium',
     icon: IconSocialMedium,
-    href: "https://quiverprotocol.medium.com/",
+    href: 'https://quiverprotocol.medium.com/',
   },
   {
-    name: "Github",
+    name: 'Github',
     icon: IconSocialGithub,
-    href: "https://github.com/QuiverCommunity",
+    href: 'https://github.com/QuiverCommunity',
   },
-];
+]
 
-export default function Footer() {
+const Footer: FunctionComponent = () => {
   return (
     <ContainerWithBackground className="xl:rounded-b-none">
       <img src="/icon.svg" className="mx-auto" />
       <Headline className="mt-12 inline-block">Ready to dive in?</Headline>
       <Title className="mt-3">Join the Community</Title>
-      <nav className="mt-12 grid md:grid-cols-3 lg:grid-cols-6 gap-6 max-w-4xl mx-auto">
-        {links.map((x, i) => (
+      <nav className="mt-12 grid md:grid-cols-3 lg:grid-cols-5 gap-6 max-w-2xl mx-auto">
+        {links.map((x) => (
           <Button key={x.name} href={x.href} icon={x.icon} outlined>
             {x.name}
           </Button>
@@ -60,5 +61,7 @@ export default function Footer() {
         © {new Date().getFullYear()} Quiver. All rights reserved.
       </Body2>
     </ContainerWithBackground>
-  );
+  )
 }
+
+export default Footer

--- a/components/layouts/footer/footer.tsx
+++ b/components/layouts/footer/footer.tsx
@@ -50,7 +50,7 @@ const Footer: FunctionComponent = () => {
       <img src="/icon.svg" className="mx-auto" />
       <Headline className="mt-12 inline-block">Ready to dive in?</Headline>
       <Title className="mt-3">Join the Community</Title>
-      <nav className="mt-12 grid md:grid-cols-3 lg:grid-cols-5 gap-6 max-w-2xl mx-auto">
+      <nav className="mt-12 grid md:grid-cols-3 lg:grid-cols-6 gap-6 max-w-4xl mx-auto">
         {links.map((x) => (
           <Button key={x.name} href={x.href} icon={x.icon} outlined>
             {x.name}

--- a/components/layouts/navigation/item.tsx
+++ b/components/layouts/navigation/item.tsx
@@ -1,20 +1,28 @@
-import { INavigationItem } from "./types";
+import { FunctionComponent } from 'react'
+import { INavigationItem } from './types'
 
-export default function Item(item: INavigationItem) {
+type IProps = {
+  item: INavigationItem
+}
+
+const Item: FunctionComponent<IProps> = (props) => {
   const handleClick = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    document.getElementById(item.id).scrollIntoView({ behavior: "smooth" });
-  };
+    event.preventDefault()
+    event.stopPropagation()
+    document
+      .getElementById(props.item.id)
+      .scrollIntoView({ behavior: 'smooth' })
+  }
 
   return (
     <a
-      key={item.key}
-      href={item.href ? item.href : `#${item.id}`}
-      onClick={item.id && handleClick}
+      href={props.item.href ? props.item.href : `#${props.item.id}`}
+      onClick={props.item.id && handleClick}
       className="text-base text-gray-500 hover:text-gray-900"
     >
-      {item.name}
+      {props.item.name}
     </a>
-  );
+  )
 }
+
+export default Item

--- a/components/layouts/navigation/navigation.tsx
+++ b/components/layouts/navigation/navigation.tsx
@@ -1,55 +1,55 @@
-import { Fragment } from "react";
-import { Popover, Transition } from "@headlessui/react";
-import { MenuIcon, XIcon, DocumentTextIcon } from "@heroicons/react/outline";
-import { INavigationItem } from "./types";
-import Item from "./item";
-import Button from "../../button/button";
+import { Popover, Transition } from '@headlessui/react'
+import { DocumentTextIcon, MenuIcon, XIcon } from '@heroicons/react/outline'
+import { Fragment, FunctionComponent } from 'react'
+import Button from '../../button/button'
+import Item from './item'
+import { INavigationItem } from './types'
 
 const action: INavigationItem = {
-  key: "whitepaper",
-  name: "Whitepaper",
-  href: "/Quiver-Whitepaper.pdf",
-};
+  key: 'whitepaper',
+  name: 'Whitepaper',
+  href: '/Quiver-Whitepaper.pdf',
+}
 
 const navigation: INavigationItem[] = [
   {
-    key: "protocol",
-    name: "Protocol",
-    id: "protocol",
+    key: 'protocol',
+    name: 'Protocol',
+    id: 'protocol',
   },
   {
-    key: "ecosystem",
-    name: "Ecosystem",
-    id: "ecosystem",
+    key: 'ecosystem',
+    name: 'Ecosystem',
+    id: 'ecosystem',
   },
   {
-    key: "invest",
-    name: "Invest",
-    id: "invest",
+    key: 'invest',
+    name: 'Invest',
+    id: 'invest',
   },
   {
-    key: "roadmap",
-    name: "Roadmap",
-    id: "roadmap",
+    key: 'roadmap',
+    name: 'Roadmap',
+    id: 'roadmap',
   },
   {
-    key: "blog",
-    name: "Blog",
-    href: "https://quiverprotocol.medium.com/",
+    key: 'blog',
+    name: 'Blog',
+    href: 'https://quiverprotocol.medium.com/',
   },
   {
-    key: "careers",
-    name: "Careers",
-    href: "https://quiverprotocol.medium.com/careers-at-quiver-protocol-b8ffd3d59d6b",
+    key: 'careers',
+    name: 'Careers',
+    href: 'https://quiverprotocol.medium.com/careers-at-quiver-protocol-b8ffd3d59d6b',
   },
   {
-    key: "guidance",
-    name: "User Guidance",
-    href: "/Quiver_Protocol_User_Guidance.pdf",
+    key: 'guidance',
+    name: 'User Guidance',
+    href: '/Quiver_Protocol_User_Guidance.pdf',
   },
-];
+]
 
-export default function Navigation() {
+const Navigation: FunctionComponent = () => {
   return (
     <Popover className="relative z-50">
       {({ open }) => (
@@ -62,7 +62,9 @@ export default function Navigation() {
               </a>
             </div>
             <nav className="hidden lg:flex space-x-10">
-              {navigation.map(Item)}
+              {navigation.map((x) => (
+                <Item key={x.key} item={x} />
+              ))}
             </nav>
             <div className="hidden lg:flex items-center justify-end lg:flex-1 lg:w-0">
               <Button href={action.href} icon={DocumentTextIcon} outlined>
@@ -105,7 +107,9 @@ export default function Navigation() {
                   </div>
                   <div className="mt-6">
                     <nav className="grid grid-cols-1 gap-7">
-                      {navigation.map(Item)}
+                      {navigation.map((x) => (
+                        <Item key={x.key} item={x} />
+                      ))}
                     </nav>
                   </div>
                 </div>
@@ -125,5 +129,7 @@ export default function Navigation() {
         </>
       )}
     </Popover>
-  );
+  )
 }
+
+export default Navigation

--- a/components/layouts/navigation/types.ts
+++ b/components/layouts/navigation/types.ts
@@ -1,6 +1,6 @@
 export type INavigationItem = {
-  key: string;
-  name: string;
-  href?: string;
-  id?: string;
-};
+  key: string
+  name: string
+  href?: string
+  id?: string
+}

--- a/components/newsletter/newsletter.tsx
+++ b/components/newsletter/newsletter.tsx
@@ -1,12 +1,11 @@
-import { PropsWithChildren, useState } from "react";
-import Button from "../button/button";
+import { FunctionComponent, useState } from 'react'
 
 type IProps = {
-  className?: string;
-};
+  className?: string
+}
 
-export default function Newsletter(props: PropsWithChildren<IProps>) {
-  const [email, setEmail] = useState("");
+const Newsletter: FunctionComponent<IProps> = (props) => {
+  const [email, setEmail] = useState('')
 
   return (
     <form
@@ -39,5 +38,7 @@ export default function Newsletter(props: PropsWithChildren<IProps>) {
         </button>
       </div>
     </form>
-  );
+  )
 }
+
+export default Newsletter

--- a/components/scroll-button/scroll-button.tsx
+++ b/components/scroll-button/scroll-button.tsx
@@ -1,35 +1,35 @@
-import { ChevronUpIcon } from "@heroicons/react/outline";
-import classNames from "classnames";
-import React, { useEffect, useState } from "react";
-import Button from "../button/button";
+import { ChevronUpIcon } from '@heroicons/react/outline'
+import classNames from 'classnames'
+import React, { FunctionComponent, useEffect, useState } from 'react'
+import Button from '../button/button'
 
-export default function ScrollButton() {
-  const [visible, setVisible] = useState(false);
+const ScrollButton: FunctionComponent = () => {
+  const [visible, setVisible] = useState(false)
 
   const toggleVisible = () => {
-    setVisible(document.documentElement.scrollTop > 300);
-  };
+    setVisible(document.documentElement.scrollTop > 300)
+  }
 
   const scrollToTop = (e) => {
-    e.stopPropagation();
-    e.preventDefault();
+    e.stopPropagation()
+    e.preventDefault()
     window.scrollTo({
       top: 0,
-      behavior: "smooth",
-    });
-  };
+      behavior: 'smooth',
+    })
+  }
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.addEventListener("scroll", toggleVisible);
-    return () => window.removeEventListener("scroll", toggleVisible);
-  }, []);
+    if (typeof window === 'undefined') return
+    window.addEventListener('scroll', toggleVisible)
+    return () => window.removeEventListener('scroll', toggleVisible)
+  }, [])
 
   return (
     <Button
       className={classNames(
-        "fixed bottom-0 right-0 m-6 z-50",
-        visible ? "invisible md:visible" : "invisible"
+        'fixed bottom-0 right-0 m-6 z-50',
+        visible ? 'invisible md:visible' : 'invisible',
       )}
       outlined
       large
@@ -37,5 +37,7 @@ export default function ScrollButton() {
       shadow
       onClick={scrollToTop}
     />
-  );
+  )
 }
+
+export default ScrollButton

--- a/components/templates/ecosystem/ecosystem.tsx
+++ b/components/templates/ecosystem/ecosystem.tsx
@@ -1,10 +1,11 @@
-import Container from "../../container/container";
-import Body1 from "../../text/body1";
-import Headline from "../../text/headline";
-import Title from "../../text/title";
-import Products from "./products";
+import { FunctionComponent } from 'react'
+import Container from '../../container/container'
+import Body1 from '../../text/body1'
+import Headline from '../../text/headline'
+import Title from '../../text/title'
+import Products from './products'
 
-export default function Ecosystem() {
+const Ecosystem: FunctionComponent = () => {
   return (
     <Container className="text-center" id="ecosystem">
       <Headline>Quiver Upcoming Ecosystem</Headline>
@@ -27,5 +28,7 @@ export default function Ecosystem() {
 
       <Products />
     </Container>
-  );
+  )
 }
+
+export default Ecosystem

--- a/components/templates/ecosystem/product.tsx
+++ b/components/templates/ecosystem/product.tsx
@@ -1,20 +1,24 @@
-import Body2 from "../../text/body2";
-import { IProduct } from "./types";
+import { FunctionComponent } from 'react'
+import Body2 from '../../text/body2'
+import { IProduct } from './types'
 
-export default function Product(product: IProduct) {
+type IProps = {
+  product: IProduct
+}
+
+const Product: FunctionComponent<IProps> = (props) => {
   return (
-    <div
-      key={product.name}
-      className="relative text-left bg-white rounded-2xl shadow-xl px-6 pt-16 pb-8"
-    >
+    <div className="relative text-left bg-white rounded-2xl shadow-xl px-6 pt-16 pb-8">
       <div className="absolute top-0 p-3 inline-block bg-gradient-to-r from-purple-100 to-purple-50 rounded-xl transform -translate-y-6">
-        <product.icon className="text-purple-900" aria-hidden="true" />
+        <props.product.icon className="text-purple-900" aria-hidden="true" />
       </div>
       <h3 className="text-lg font-semibold leading-6 text-purple-900">
-        {product.name}
+        {props.product.name}
       </h3>
-      <Body2 className="mt-3">{product.description}</Body2>
+      <Body2 className="mt-3">{props.product.description}</Body2>
       <a className="block mt-6 text-primary">Coming soon 🔥</a>
     </div>
-  );
+  )
 }
+
+export default Product

--- a/components/templates/ecosystem/products.tsx
+++ b/components/templates/ecosystem/products.tsx
@@ -1,38 +1,43 @@
-import IconAnalyse from "../../icon/analyse";
-import IconIDAO from "../../icon/idao";
-import IconLending from "../../icon/lending";
-import Product from "./product";
+import { FunctionComponent } from 'react'
+import IconAnalyse from '../../icon/analyse'
+import IconIDAO from '../../icon/idao'
+import IconLending from '../../icon/lending'
+import Product from './product'
 
 const supportLinks = [
   {
-    name: "Quiver IDAO",
+    name: 'Quiver IDAO',
     description:
-      "The first investment DAO running on Quiver Protocol. Any users could join here for co-investment with other professionals and get voting power through our QSTK Token for the funds movement.",
+      'The first investment DAO running on Quiver Protocol. Any users could join here for co-investment with other professionals and get voting power through our QSTK Token for the funds movement.',
     icon: IconIDAO,
   },
   {
-    name: "Market Analysis Group",
+    name: 'Market Analysis Group',
     description:
-      "Market Analysis Group will be organized to scout and explore new investment opportunities to give the community well informed financial decisions through vetted information and lead them to the right direction.",
+      'Market Analysis Group will be organized to scout and explore new investment opportunities to give the community well informed financial decisions through vetted information and lead them to the right direction.',
     icon: IconAnalyse,
   },
   {
-    name: "Lending & Borrowing",
+    name: 'Lending & Borrowing',
     description:
-      "Lending & Borrowing is a bonus service for reputational users. Community members provide lending for reputation collateral. As an option, high reputation users can borrow directly from the protocol treasury.",
+      'Lending & Borrowing is a bonus service for reputational users. Community members provide lending for reputation collateral. As an option, high reputation users can borrow directly from the protocol treasury.',
     icon: IconLending,
   },
-];
+]
 
-export default function Products() {
+const Products: FunctionComponent = () => {
   return (
     <section
       className="-mt-12 max-w-7xl mx-auto relative z-10"
       aria-labelledby="contact-heading"
     >
       <div className="grid grid-cols-1 gap-y-20 lg:grid-cols-3 lg:gap-y-0 lg:gap-x-6">
-        {supportLinks.map(Product)}
+        {supportLinks.map((x) => (
+          <Product key={x.name} product={x} />
+        ))}
       </div>
     </section>
-  );
+  )
 }
+
+export default Products

--- a/components/templates/ecosystem/types.ts
+++ b/components/templates/ecosystem/types.ts
@@ -1,6 +1,6 @@
 export type IProduct = {
-  name: string;
-  description: string;
-  href?: string;
-  icon: any;
-};
+  name: string
+  description: string
+  href?: string
+  icon: any
+}

--- a/components/templates/features/benefit.tsx
+++ b/components/templates/features/benefit.tsx
@@ -1,17 +1,21 @@
-import { IBenefit } from "./types";
+import { FunctionComponent } from 'react'
+import { IBenefit } from './types'
 
-export default function Benefit(benefit: IBenefit) {
+type IProps = {
+  benefit: IBenefit
+}
+
+const Benefit: FunctionComponent<IProps> = (props) => {
   return (
-    <div
-      key={benefit.name}
-      className="flow-root bg-white rounded-xl shadow-xl px-8 py-16"
-    >
+    <div className="flow-root bg-white rounded-xl shadow-xl px-8 py-16">
       <span className="inline-flex items-center justify-center p-3 bg-gradient-to-r from-purple-100 to-purple-50 rounded-xl">
-        <span className="w-10 h-10 text-4xl">{benefit.icon}</span>
+        <span className="w-10 h-10 text-4xl">{props.benefit.icon}</span>
       </span>
       <h3 className="mt-8 text-lg leading-6 font-medium text-purple-900 tracking-tight">
-        {benefit.description}
+        {props.benefit.description}
       </h3>
     </div>
-  );
+  )
 }
+
+export default Benefit

--- a/components/templates/features/benefits.tsx
+++ b/components/templates/features/benefits.tsx
@@ -1,41 +1,46 @@
-import Subtitle2 from "../../text/subtitle2";
-import Benefit from "./benefit";
-import { IBenefit } from "./types";
+import { FunctionComponent } from 'react'
+import Subtitle2 from '../../text/subtitle2'
+import Benefit from './benefit'
+import { IBenefit } from './types'
 
 const benefits: IBenefit[] = [
   {
-    name: "Access Time",
-    description: "Reduce required time to access information",
-    icon: "⏱",
+    name: 'Access Time',
+    description: 'Reduce required time to access information',
+    icon: '⏱',
   },
   {
-    name: "ROI Performance",
-    description: "Increase investment ROI based on performance",
-    icon: "🚀",
+    name: 'ROI Performance',
+    description: 'Increase investment ROI based on performance',
+    icon: '🚀',
   },
   {
-    name: "Reduce Risk",
-    description: "Minimize investment risks",
-    icon: "🤝",
+    name: 'Reduce Risk',
+    description: 'Minimize investment risks',
+    icon: '🤝',
   },
   {
-    name: "Valuation",
-    description: "Maximize expected value of information",
-    icon: "💎",
+    name: 'Valuation',
+    description: 'Maximize expected value of information',
+    icon: '💎',
   },
-];
+]
 
-export default function Benefits() {
+const Benefits: FunctionComponent = () => {
   return (
     <div className="relative pt-20 pb-12">
       <div className="mx-auto max-w-md px-4 text-center sm:max-w-3xl sm:px-6 lg:px-8 lg:max-w-7xl">
         <Subtitle2 className="mt-2">Quiver Protocol Benefits</Subtitle2>
         <div className="mt-12">
           <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
-            {benefits.map(Benefit)}
+            {benefits.map((x) => (
+              <Benefit key={x.name} benefit={x} />
+            ))}
           </div>
         </div>
       </div>
     </div>
-  );
+  )
 }
+
+export default Benefits

--- a/components/templates/features/features.tsx
+++ b/components/templates/features/features.tsx
@@ -1,14 +1,15 @@
-import { DownloadIcon } from "@heroicons/react/outline";
-import Button from "../../button/button";
-import Container from "../../container/container";
-import Benefits from "./benefits";
-import Headline from "../../text/headline";
-import Title from "../../text/title";
-import Subtitle from "../../text/subtitle";
-import Body1 from "../../text/body1";
-import Body2 from "../../text/body2";
+import { DownloadIcon } from '@heroicons/react/outline'
+import { FunctionComponent } from 'react'
+import Button from '../../button/button'
+import Container from '../../container/container'
+import Body1 from '../../text/body1'
+import Body2 from '../../text/body2'
+import Headline from '../../text/headline'
+import Subtitle from '../../text/subtitle'
+import Title from '../../text/title'
+import Benefits from './benefits'
 
-export default function Protocol() {
+const Protocol: FunctionComponent = () => {
   return (
     <Container className="text-center" id="protocol">
       <Headline>Quiver Community Vision</Headline>
@@ -90,5 +91,7 @@ export default function Protocol() {
         </div>
       </div>
     </Container>
-  );
+  )
 }
+
+export default Protocol

--- a/components/templates/features/types.ts
+++ b/components/templates/features/types.ts
@@ -1,5 +1,5 @@
 export type IBenefit = {
-  name: string;
-  description: string;
-  icon: any;
-};
+  name: string
+  description: string
+  icon: any
+}

--- a/components/templates/hero/hero.tsx
+++ b/components/templates/hero/hero.tsx
@@ -1,25 +1,25 @@
-import { PropsWithChildren } from "react";
-import Button from "../../button/button";
-import Container from "../../container/container";
-import Tag from "../../text/tag";
-import Body1 from "../../text/body1";
-import MainTitle from "../../text/main-title";
-import Subtitle2 from "../../text/subtitle2";
-import Member from "./member";
-import { IMember } from "./types";
-import IconSocialDiscord from "../../icon/social/discord";
-import IconSocialTelegram from "../../icon/social/telegram";
+import { FunctionComponent } from 'react'
+import Button from '../../button/button'
+import Container from '../../container/container'
+import IconSocialDiscord from '../../icon/social/discord'
+import IconSocialTelegram from '../../icon/social/telegram'
+import Body1 from '../../text/body1'
+import MainTitle from '../../text/main-title'
+import Subtitle2 from '../../text/subtitle2'
+import Tag from '../../text/tag'
+import Member from './member'
+import { IMember } from './types'
 
 type IProps = {
-  members: IMember[];
-};
+  members: IMember[]
+}
 
-export default function Hero(props: PropsWithChildren<IProps>) {
+const Hero: FunctionComponent<IProps> = (props) => {
   return (
     <div className="relative">
       <div
         className="absolute -top-24 left-0 right-0 bottom-0 bg-local bg-top bg-no-repeat bg-cover"
-        style={{ backgroundImage: "url(/background.svg)" }}
+        style={{ backgroundImage: 'url(/background.svg)' }}
       ></div>
       <Container className="px-12 text-center">
         <div className="inline-flex items-center text-purple-900 bg-white border border-purple-300 rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base">
@@ -62,9 +62,13 @@ export default function Hero(props: PropsWithChildren<IProps>) {
 
         <Subtitle2 className="mt-12">Community Core Members</Subtitle2>
         <nav className="mt-12 flex flex-wrap justify-center">
-          {props.members.map(Member)}
+          {props.members.map((x, i) => (
+            <Member key={i} member={x} />
+          ))}
         </nav>
       </Container>
     </div>
-  );
+  )
 }
+
+export default Hero

--- a/components/templates/hero/member.tsx
+++ b/components/templates/hero/member.tsx
@@ -1,20 +1,24 @@
-import Body2 from "../../text/body2";
-import { IMember } from "./types";
+import { FunctionComponent } from 'react'
+import Body2 from '../../text/body2'
+import { IMember } from './types'
 
-export default function Member(member: IMember) {
+type IProps = {
+  member: IMember
+}
+
+const Member: FunctionComponent<IProps> = (props) => {
   return (
-    <div
-      key={member.name}
-      className="rounded-full border border-purple-200 p-2 pr-6 mx-3 mt-3"
-    >
+    <div className="rounded-full border border-purple-200 p-2 pr-6 mx-3 mt-3">
       <div className="flex items-center">
         <img
           className="inline-block h-8 w-8 rounded-full"
-          src={member.imageUrl}
-          alt={member.name}
+          src={props.member.imageUrl}
+          alt={props.member.name}
         />
-        <Body2 className="ml-3">{member.name}</Body2>
+        <Body2 className="ml-3">{props.member.name}</Body2>
       </div>
     </div>
-  );
+  )
 }
+
+export default Member

--- a/components/templates/hero/types.ts
+++ b/components/templates/hero/types.ts
@@ -1,5 +1,5 @@
 export type IMember = {
-  name: string;
-  role: string;
-  imageUrl: string;
-};
+  name: string
+  role: string
+  imageUrl: string
+}

--- a/components/templates/information/information.tsx
+++ b/components/templates/information/information.tsx
@@ -1,24 +1,27 @@
-import ContainerWithBackground from "../../container/container-with-background";
-import IconArrowSmall from "../../icon/arrow-small";
+import { FunctionComponent } from 'react'
+import ContainerWithBackground from '../../container/container-with-background'
+import IconArrowSmall from '../../icon/arrow-small'
 
-export default function Information() {
+const Information: FunctionComponent = () => {
   return (
     <ContainerWithBackground>
       <h2 className="text-3xl font-light tracking-tight sm:text-4xl">
         🤔
-        <IconArrowSmall className="inline mx-2 -mt-2" />{" "}
-        <img src="/icon.svg" className="inline w-10 h-10 align-top" />{" "}
+        <IconArrowSmall className="inline mx-2 -mt-2" />{' '}
+        <img src="/icon.svg" className="inline w-10 h-10 align-top" />{' '}
         <IconArrowSmall className="inline mx-2 -mt-2" />
         🤑
       </h2>
       <p className="mt-6 text-2xl leading-8 font-normal mx-auto max-w-2xl text-purple-900">
         Investment information is hard to value, access and trust.
         <br />
-        Our mission is to make our pre-vetted investment information,{" "}
-        <span className="font-bold">profitable</span>,{" "}
-        <span className="font-bold">trustable</span> and{" "}
+        Our mission is to make our pre-vetted investment information,{' '}
+        <span className="font-bold">profitable</span>,{' '}
+        <span className="font-bold">trustable</span> and{' '}
         <span className="font-bold">accessible</span> to everyone.
       </p>
     </ContainerWithBackground>
-  );
+  )
 }
+
+export default Information

--- a/components/templates/inverstor/benefit.tsx
+++ b/components/templates/inverstor/benefit.tsx
@@ -1,22 +1,29 @@
-import Body2 from "../../text/body2";
-import { IBenefit } from "./types";
+import { FunctionComponent } from 'react'
+import Body2 from '../../text/body2'
+import { IBenefit } from './types'
 
-export default function Benefit(benefit: IBenefit) {
+type IProps = {
+  benefit: IBenefit
+}
+
+const Benefit: FunctionComponent<IProps> = (props) => {
   return (
-    <div key={benefit.name} className="p-8 ring-1 ring-purple-300 rounded-xl col-span-3">
+    <div className="p-8 ring-1 ring-purple-300 rounded-xl col-span-3">
       <h3 className="inline text-xl leading-7 font-bold bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary">
-        {benefit.name}
+        {props.benefit.name}
       </h3>
       <Body2 className="mt-2" color="text-gray-400">
-        [ {benefit.category} ]
+        [ {props.benefit.category} ]
       </Body2>
       <ul className="list-disc list-inside mt-6 text-purple-900">
-        {benefit.items.map((item, i) => (
+        {props.benefit.items.map((item, i) => (
           <li key={i} className="mt-4 text-base leading-6 font-normal">
             {item}
           </li>
         ))}
       </ul>
     </div>
-  );
+  )
 }
+
+export default Benefit

--- a/components/templates/inverstor/investor.tsx
+++ b/components/templates/inverstor/investor.tsx
@@ -1,95 +1,95 @@
-import { Fragment } from "react";
-import Container from "../../container/container";
-import IconCryptoBtc from "../../icon/crypto/BTC";
-import IconCryptoEth from "../../icon/crypto/ETH";
-import Newsletter from "../../newsletter/newsletter";
-import Body1 from "../../text/body1";
-import Body2 from "../../text/body2";
-import Headline from "../../text/headline";
-import Subtitle2 from "../../text/subtitle2";
-import Title from "../../text/title";
-import Benefit from "./benefit";
-import NFT from "./nft";
-import { IBenefit, INFT } from "./types";
+import { Fragment, FunctionComponent } from 'react'
+import Container from '../../container/container'
+import IconCryptoBtc from '../../icon/crypto/BTC'
+import IconCryptoEth from '../../icon/crypto/ETH'
+import Newsletter from '../../newsletter/newsletter'
+import Body1 from '../../text/body1'
+import Body2 from '../../text/body2'
+import Headline from '../../text/headline'
+import Subtitle2 from '../../text/subtitle2'
+import Title from '../../text/title'
+import Benefit from './benefit'
+import NFT from './nft'
+import { IBenefit, INFT } from './types'
 
 const nfts: INFT[] = [
   {
-    name: "Fish",
-    category: "Silver",
+    name: 'Fish',
+    category: 'Silver',
     crypto: IconCryptoBtc,
-    progress: "up",
-    imageUrl: "/nfts/fish/silver/happy.png",
+    progress: 'up',
+    imageUrl: '/nfts/fish/silver/happy.png',
   },
   {
-    name: "Dragon",
-    category: "Platinium",
+    name: 'Dragon',
+    category: 'Platinium',
     crypto: IconCryptoEth,
-    progress: "stable",
-    imageUrl: "/nfts/dragon/platinum/normal.png",
+    progress: 'stable',
+    imageUrl: '/nfts/dragon/platinum/normal.png',
   },
   {
-    name: "Bull",
-    category: "Bronze",
+    name: 'Bull',
+    category: 'Bronze',
     crypto: IconCryptoBtc,
-    progress: "down",
-    imageUrl: "/nfts/bull/bronze/angry.png",
+    progress: 'down',
+    imageUrl: '/nfts/bull/bronze/angry.png',
   },
   {
-    name: "Dear",
-    category: "Bronze",
+    name: 'Dear',
+    category: 'Bronze',
     crypto: IconCryptoEth,
-    progress: "down",
-    imageUrl: "/nfts/deer/bronze/angry.png",
+    progress: 'down',
+    imageUrl: '/nfts/deer/bronze/angry.png',
   },
   {
-    name: "Bear",
-    category: "Diamond",
+    name: 'Bear',
+    category: 'Diamond',
     crypto: IconCryptoBtc,
-    progress: "stable",
-    imageUrl: "/nfts/bear/diamond/normal.png",
+    progress: 'stable',
+    imageUrl: '/nfts/bear/diamond/normal.png',
   },
   {
-    name: "Whale",
-    category: "Diamond",
+    name: 'Whale',
+    category: 'Diamond',
     crypto: IconCryptoEth,
-    progress: "up",
-    imageUrl: "/nfts/whale/diamond/happy.png",
+    progress: 'up',
+    imageUrl: '/nfts/whale/diamond/happy.png',
   },
-];
+]
 
 const benefits: IBenefit[] = [
   {
-    name: "Emotional NFT",
-    category: "Community Art NFTs",
+    name: 'Emotional NFT',
+    category: 'Community Art NFTs',
     items: [
-      "Lovely art for stressless investment",
-      "Get access to locked assets sale",
-      "Community gamification",
+      'Lovely art for stressless investment',
+      'Get access to locked assets sale',
+      'Community gamification',
     ],
   },
   {
-    name: "QREP Token",
-    category: "Reputation Token",
+    name: 'QREP Token',
+    category: 'Reputation Token',
     items: [
-      "Get initial reputation in the ecosystem with QREP Token",
-      "Access DICP voting power",
-      "Unlock DICP protocol rewards",
-      "Trust from the community",
+      'Get initial reputation in the ecosystem with QREP Token',
+      'Access DICP voting power',
+      'Unlock DICP protocol rewards',
+      'Trust from the community',
     ],
   },
   {
-    name: "QSTK Token",
-    category: "Economy Token",
+    name: 'QSTK Token',
+    category: 'Economy Token',
     items: [
-      "Receive QSTK Token at a discounted price (locked asset)",
-      "Access Quiver IDAO voting power",
-      "Get discounted price on information purchase from the DICP",
-      "Unlock DICP protocol rewards",
+      'Receive QSTK Token at a discounted price (locked asset)',
+      'Access Quiver IDAO voting power',
+      'Get discounted price on information purchase from the DICP',
+      'Unlock DICP protocol rewards',
     ],
   },
-];
+]
 
-export default function Investor() {
+const Investor: FunctionComponent = () => {
   return (
     <Container id="invest">
       <div className="lg:grid lg:grid-cols-5 lg:grid-flow-col-dense lg:gap-8">
@@ -125,7 +125,7 @@ export default function Investor() {
       </Subtitle2>
       <div className="mt-12">
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-11">
-          {benefits.map(({ category, items, name }, i) => (
+          {benefits.map((x, i) => (
             <Fragment key={i}>
               {i > 0 && (
                 <div className="flex items-center">
@@ -134,11 +134,13 @@ export default function Investor() {
                   </span>
                 </div>
               )}
-              <Benefit name={name} category={category} items={items} />
+              <Benefit benefit={x} />
             </Fragment>
           ))}
         </div>
       </div>
     </Container>
-  );
+  )
 }
+
+export default Investor

--- a/components/templates/inverstor/nft.tsx
+++ b/components/templates/inverstor/nft.tsx
@@ -1,42 +1,42 @@
-import classNames from "classnames";
-import { PropsWithChildren } from "react";
-import IconTrendDown from "../../icon/trend/down";
-import IconTrendStable from "../../icon/trend/stable";
-import IconTrendUp from "../../icon/trend/up";
-import Body2 from "../../text/body2";
-import { INFT } from "./types";
+import classNames from 'classnames'
+import { FunctionComponent } from 'react'
+import IconTrendDown from '../../icon/trend/down'
+import IconTrendStable from '../../icon/trend/stable'
+import IconTrendUp from '../../icon/trend/up'
+import Body2 from '../../text/body2'
+import { INFT } from './types'
 
 type IProps = {
-  index: number;
-  nft: INFT;
-};
+  index: number
+  nft: INFT
+}
 
-export default function NFT(props: PropsWithChildren<IProps>) {
+const NFT: FunctionComponent<IProps> = (props) => {
   const config = {
     up: {
-      color: "green",
-      text: "Happy",
+      color: 'green',
+      text: 'Happy',
       icon: IconTrendUp,
     },
     down: {
-      color: "red",
-      text: "Angry",
+      color: 'red',
+      text: 'Angry',
       icon: IconTrendDown,
     },
     stable: {
-      color: "blue",
-      text: "Rest",
+      color: 'blue',
+      text: 'Rest',
       icon: IconTrendStable,
     },
-  }[props.nft.progress];
+  }[props.nft.progress]
 
   return (
     <div>
       <div
         className={classNames(
-          "p-6 ring-2 ring-purple-200 rounded-xl shadow-xl bg-gradient-to-t via-white to-white w-44 mx-auto",
+          'p-6 ring-2 ring-purple-200 rounded-xl shadow-xl bg-gradient-to-t via-white to-white w-44 mx-auto',
           `from-${config.color}-50`,
-          props.index < 3 && props.index % 3 !== 1 ? "md:mt-12" : ""
+          props.index < 3 && props.index % 3 !== 1 ? 'md:mt-12' : '',
         )}
       >
         <div className="flex justify-between">
@@ -53,7 +53,7 @@ export default function NFT(props: PropsWithChildren<IProps>) {
         <img
           src={props.nft.imageUrl}
           className={`mt-6 mx-auto w-32 h-32 ${
-            props.index % 3 == 1 ? "md:mt-12 md:mb-12" : ""
+            props.index % 3 == 1 ? 'md:mt-12 md:mb-12' : ''
           }`}
         />
         <Body2 className="mt-6 font-bold">{props.nft.name}</Body2>
@@ -62,5 +62,7 @@ export default function NFT(props: PropsWithChildren<IProps>) {
         </p>
       </div>
     </div>
-  );
+  )
 }
+
+export default NFT

--- a/components/templates/inverstor/types.ts
+++ b/components/templates/inverstor/types.ts
@@ -1,13 +1,13 @@
 export type INFT = {
-  name: string;
-  imageUrl: string;
-  category: "Silver" | "Platinium" | "Bronze" | "Diamond";
-  crypto: any;
-  progress: "up" | "down" | "stable";
-};
+  name: string
+  imageUrl: string
+  category: 'Silver' | 'Platinium' | 'Bronze' | 'Diamond'
+  crypto: any
+  progress: 'up' | 'down' | 'stable'
+}
 
 export type IBenefit = {
-  name: string;
-  category: string;
-  items: string[];
-};
+  name: string
+  category: string
+  items: string[]
+}

--- a/components/templates/roadmap/quarter.tsx
+++ b/components/templates/roadmap/quarter.tsx
@@ -1,19 +1,23 @@
-import { Fragment } from "react";
-import IconArrowLarge from "../../icon/arrow-large";
-import { IQuarter } from "./types";
+import { Fragment, FunctionComponent } from 'react'
+import IconArrowLarge from '../../icon/arrow-large'
+import { IQuarter } from './types'
 
-export default function Quarter(quarter: IQuarter) {
+type IProps = {
+  quarter: IQuarter
+}
+
+const Quarter: FunctionComponent<IProps> = (props) => {
   return (
-    <div className="text-left" key={quarter.quarter}>
+    <div className="text-left">
       <div className="flex">
         <span className="mr-6 bg-gradient-to-r from-purple-100 to-purple-50 p-3 rounded-xl text-lg leading-6 font-semibold">
-          {quarter.quarter}
+          {props.quarter.quarter}
         </span>
         <IconArrowLarge className="inline mt-4" />
       </div>
       <div className="pl-12 pt-6">
         <dl className="ml-6">
-          {quarter.steps.map((x, i) => (
+          {props.quarter.steps.map((x, i) => (
             <Fragment key={i}>
               <dt className="float-left">
                 <span className="text-2xl mr-3">{x.icon}</span>
@@ -26,5 +30,7 @@ export default function Quarter(quarter: IQuarter) {
         </dl>
       </div>
     </div>
-  );
+  )
 }
+
+export default Quarter

--- a/components/templates/roadmap/roadmap.tsx
+++ b/components/templates/roadmap/roadmap.tsx
@@ -1,90 +1,91 @@
-import { DownloadIcon } from "@heroicons/react/outline";
-import Button from "../../button/button";
-import Container from "../../container/container";
-import Headline from "../../text/headline";
-import Title from "../../text/title";
-import Quarter from "./quarter";
-import { IQuarter } from "./types";
+import { DownloadIcon } from '@heroicons/react/outline'
+import { FunctionComponent } from 'react'
+import Button from '../../button/button'
+import Container from '../../container/container'
+import Headline from '../../text/headline'
+import Title from '../../text/title'
+import Quarter from './quarter'
+import { IQuarter } from './types'
 
 const roadmap: IQuarter[] = [
   {
-    quarter: "Q2",
+    quarter: 'Q2',
     steps: [
       {
-        title: "Whitepaper writing",
-        icon: "📝",
+        title: 'Whitepaper writing',
+        icon: '📝',
       },
       {
-        title: "Community introduction & marketing materials",
-        icon: "👋",
+        title: 'Community introduction & marketing materials',
+        icon: '👋',
       },
       {
-        title: "Emotional NFTs Sale",
-        icon: "😻",
+        title: 'Emotional NFTs Sale',
+        icon: '😻',
       },
       {
-        title: "Community Seed investors",
-        icon: "💸",
+        title: 'Community Seed investors',
+        icon: '💸',
       },
       {
-        title: "Initial community setup",
-        icon: "🎉",
+        title: 'Initial community setup',
+        icon: '🎉',
       },
       {
-        title: "Initial Quiver IDAO governance setup",
-        icon: "⚖️",
+        title: 'Initial Quiver IDAO governance setup',
+        icon: '⚖️',
       },
     ],
   },
   {
-    quarter: "Q3",
+    quarter: 'Q3',
     steps: [
       {
-        title: "Finalization of Quiver IDAO governance setup",
-        icon: "⚖️",
+        title: 'Finalization of Quiver IDAO governance setup',
+        icon: '⚖️',
       },
       {
-        title: "DICP MVP product",
-        icon: "🚀",
+        title: 'DICP MVP product',
+        icon: '🚀',
       },
       {
-        title: "DAO service management product",
-        icon: "📟",
+        title: 'DAO service management product',
+        icon: '📟',
       },
       {
-        title: "Prototyping of seed DAO services",
-        icon: "🛠",
+        title: 'Prototyping of seed DAO services',
+        icon: '🛠',
       },
       {
-        title: "Community development",
-        icon: "💪",
+        title: 'Community development',
+        icon: '💪',
       },
     ],
   },
   {
-    quarter: "Q4",
+    quarter: 'Q4',
     steps: [
       {
-        title: "Implement ready-to-go product on Ethereum network",
-        icon: "🛰",
+        title: 'Implement ready-to-go product on Ethereum network',
+        icon: '🛰',
       },
       {
-        title: "QSTK Token public sale & DEX listing",
-        icon: "💰",
+        title: 'QSTK Token public sale & DEX listing',
+        icon: '💰',
       },
       {
-        title: "Partnerships development",
-        icon: "🤝",
+        title: 'Partnerships development',
+        icon: '🤝',
       },
       {
-        title: "Protocol governance setup",
-        icon: "⚖️",
+        title: 'Protocol governance setup',
+        icon: '⚖️',
       },
     ],
   },
-];
+]
 
-export default function Roadmap() {
+const Roadmap: FunctionComponent = () => {
   return (
     <Container className="text-center" id="roadmap">
       <Headline>Community Direction</Headline>
@@ -96,8 +97,12 @@ export default function Roadmap() {
       </div>
 
       <div className="mt-24 grid grid-cols-1 md:grid-cols-3 gap-8">
-        {roadmap.map(Quarter)}
+        {roadmap.map((x) => (
+          <Quarter key={x.quarter} quarter={x} />
+        ))}
       </div>
     </Container>
-  );
+  )
 }
+
+export default Roadmap

--- a/components/templates/roadmap/types.ts
+++ b/components/templates/roadmap/types.ts
@@ -1,9 +1,9 @@
 export type IStep = {
-  title: string;
-  icon: string;
-};
+  title: string
+  icon: string
+}
 
 export type IQuarter = {
-  quarter: string;
-  steps: IStep[];
-};
+  quarter: string
+  steps: IStep[]
+}

--- a/components/text/_generator.tsx
+++ b/components/text/_generator.tsx
@@ -1,27 +1,27 @@
-import classNames from "classnames";
-import { PropsWithChildren } from "react";
+import classNames from 'classnames'
+import { FunctionComponent } from 'react'
 
 type IProps = {
-  className?: string;
-  color?: string;
-};
+  className?: string
+  color?: string
+}
 
 export default function GenerateTextComponent(params: {
-  tag: keyof JSX.IntrinsicElements;
-  className: string;
-  color: string;
-}): (props: PropsWithChildren<IProps>) => any {
+  tag: keyof JSX.IntrinsicElements
+  className: string
+  color: string
+}): FunctionComponent<IProps> {
   return (props) => {
     return (
       <params.tag
         className={classNames(
           params.className,
           props.color || params.color,
-          props.className
+          props.className,
         )}
       >
         {props.children}
       </params.tag>
-    );
-  };
+    )
+  }
 }

--- a/components/text/body1.tsx
+++ b/components/text/body1.tsx
@@ -1,9 +1,9 @@
-import GenerateTextComponent from "./_generator";
+import GenerateTextComponent from './_generator'
 
 const Body1 = GenerateTextComponent({
-  tag: "p",
-  className: "text-xl leading-7 font-normal",
-  color: "text-purple-900",
-});
+  tag: 'p',
+  className: 'text-xl leading-7 font-normal',
+  color: 'text-purple-900',
+})
 
-export default Body1;
+export default Body1

--- a/components/text/body2.tsx
+++ b/components/text/body2.tsx
@@ -1,9 +1,9 @@
-import GenerateTextComponent from "./_generator";
+import GenerateTextComponent from './_generator'
 
 const Body2 = GenerateTextComponent({
-  tag: "p",
-  className: "text-base leading-6 font-normal",
-  color: "text-purple-900",
-});
+  tag: 'p',
+  className: 'text-base leading-6 font-normal',
+  color: 'text-purple-900',
+})
 
-export default Body2;
+export default Body2

--- a/components/text/headline.tsx
+++ b/components/text/headline.tsx
@@ -1,10 +1,10 @@
-import GenerateTextComponent from "./_generator";
+import GenerateTextComponent from './_generator'
 
 const Headline = GenerateTextComponent({
-  tag: "span",
-  className: "text-base leading-6 font-semibold tracking-wide uppercase",
+  tag: 'span',
+  className: 'text-base leading-6 font-semibold tracking-wide uppercase',
   color:
-    "bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary",
-});
+    'bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary',
+})
 
-export default Headline;
+export default Headline

--- a/components/text/main-title.tsx
+++ b/components/text/main-title.tsx
@@ -1,9 +1,9 @@
-import GenerateTextComponent from "./_generator";
+import GenerateTextComponent from './_generator'
 
 const MainTitle = GenerateTextComponent({
-  tag: "h1",
-  className: "text-5xl leading-none font-extrabold ",
-  color: "text-purple-900",
-});
+  tag: 'h1',
+  className: 'text-5xl leading-none font-extrabold ',
+  color: 'text-purple-900',
+})
 
-export default MainTitle;
+export default MainTitle

--- a/components/text/subtitle.tsx
+++ b/components/text/subtitle.tsx
@@ -1,9 +1,9 @@
-import GenerateTextComponent from "./_generator";
+import GenerateTextComponent from './_generator'
 
 const Subtitle = GenerateTextComponent({
-  tag: "h3",
-  className: "text-3xl leading-9 font-bold",
-  color: "text-purple-900"
-});
+  tag: 'h3',
+  className: 'text-3xl leading-9 font-bold',
+  color: 'text-purple-900',
+})
 
-export default Subtitle;
+export default Subtitle

--- a/components/text/subtitle2.tsx
+++ b/components/text/subtitle2.tsx
@@ -1,9 +1,9 @@
-import GenerateTextComponent from "./_generator";
+import GenerateTextComponent from './_generator'
 
 const Subtitle2 = GenerateTextComponent({
-  tag: "h4",
-  className: "text-2xl leading-7 font-bold ",
-  color: "text-purple-900"
-});
+  tag: 'h4',
+  className: 'text-2xl leading-7 font-bold ',
+  color: 'text-purple-900',
+})
 
-export default Subtitle2;
+export default Subtitle2

--- a/components/text/tag.tsx
+++ b/components/text/tag.tsx
@@ -1,10 +1,10 @@
-import GenerateTextComponent from "./_generator";
+import GenerateTextComponent from './_generator'
 
 const Tag = GenerateTextComponent({
-  tag: "span",
+  tag: 'span',
   className:
-    "px-3 py-0.5 text-xs font-semibold leading-5 uppercase tracking-wide rounded-full",
-  color: "text-white bg-gradient-to-r from-primary to-secondary",
-});
+    'px-3 py-0.5 text-xs font-semibold leading-5 uppercase tracking-wide rounded-full',
+  color: 'text-white bg-gradient-to-r from-primary to-secondary',
+})
 
-export default Tag;
+export default Tag

--- a/components/text/title.tsx
+++ b/components/text/title.tsx
@@ -1,9 +1,9 @@
-import GenerateTextComponent from "./_generator";
+import GenerateTextComponent from './_generator'
 
 const Title = GenerateTextComponent({
-  tag: "h2",
-  className: "text-4xl leading-10 font-extrabold tracking-tight",
-  color: "text-purple-900",
-});
+  tag: 'h2',
+  className: 'text-4xl leading-10 font-extrabold tracking-tight',
+  color: 'text-purple-900',
+})
 
-export default Title;
+export default Title

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,77 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+      "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "@fullhuman/postcss-purgecss": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.1.3.tgz",
@@ -214,10 +285,22 @@
       "integrity": "sha512-v5LyHkwXj/4lI74B06zUrmWEdmSqS43+jw717pkt3fAXqb7ALwu77A8t7j+Bej+ZbdlIIqNMYheGN7wSGV1A6w==",
       "dev": true
     },
+    "@types/json-schema": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
       "dev": true
     },
     "@types/node": {
@@ -248,10 +331,168 @@
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
       "dev": true
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.23.0.tgz",
+      "integrity": "sha512-tGK1y3KIvdsQEEgq6xNn1DjiFJtl+wn8JJQiETtCbdQxw1vzjXyAaIkEmO2l6Nq24iy3uZBMFQjZ6ECf1QdgGw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "4.23.0",
+        "@typescript-eslint/scope-manager": "4.23.0",
+        "debug": "^4.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "lodash": "^4.17.15",
+        "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.23.0.tgz",
+      "integrity": "sha512-WAFNiTDnQfrF3Z2fQ05nmCgPsO5o790vOhmWKXbbYQTO9erE1/YsFot5/LnOUizLzU2eeuz6+U/81KV5/hFTGA==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/scope-manager": "4.23.0",
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/typescript-estree": "4.23.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.23.0.tgz",
+      "integrity": "sha512-wsvjksHBMOqySy/Pi2Q6UuIuHYbgAMwLczRl4YanEPKW5KVxI9ZzDYh3B5DtcZPQTGRWFJrfcbJ6L01Leybwug==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "4.23.0",
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/typescript-estree": "4.23.0",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.23.0.tgz",
+      "integrity": "sha512-ZZ21PCFxPhI3n0wuqEJK9omkw51wi2bmeKJvlRZPH5YFkcawKOuRMQMnI8mH6Vo0/DoHSeZJnHiIx84LmVQY+w==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/visitor-keys": "4.23.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.23.0.tgz",
+      "integrity": "sha512-oqkNWyG2SLS7uTWLZf6Sr7Dm02gA5yxiz1RP87tvsmDsguVATdpVguHr4HoGOcFOpCvx9vtCSCyQUGfzq28YCw==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.23.0.tgz",
+      "integrity": "sha512-5Sty6zPEVZF5fbvrZczfmLCOcby3sfrSPu30qKoY1U3mca5/jvU5cwsPb/CO6Q3ByRjixTMIVsDkqwIxCf/dMw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/visitor-keys": "4.23.0",
+        "debug": "^4.1.1",
+        "globby": "^11.0.1",
+        "is-glob": "^4.0.1",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.23.0.tgz",
+      "integrity": "sha512-5PNe5cmX9pSifit0H+nPoQBXdbNzi5tOEec+3riK+ku4e3er37pKxMKDH5Ct5Y4fhWxcD4spnlYjxi9vXbSpwg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.23.0",
+        "eslint-visitor-keys": "^2.0.0"
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
     },
     "acorn-node": {
@@ -271,10 +512,28 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "anser": {
       "version": "1.4.9",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.9.tgz",
       "integrity": "sha512-AI+BjTeGt2+WFk4eWcqbQ7snZpDBt8SaLlj0RT2h5xfdWaiy51OjYvqwMrNzJLGy8iOAL6nKDITWO+rd4MkYEA=="
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -307,10 +566,52 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-differ": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+      "dev": true
+    },
     "array-filter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
+    "array-includes": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.5"
+      }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      }
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true
     },
     "asn1.js": {
       "version": "5.4.1",
@@ -345,6 +646,12 @@
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
       "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA=="
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -700,6 +1007,12 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -780,6 +1093,17 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       }
     },
     "crypto-browserify": {
@@ -897,6 +1221,12 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -959,11 +1289,29 @@
         }
       }
     },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "domain-browser": {
       "version": "4.19.0",
@@ -1002,6 +1350,12 @@
         }
       }
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -1013,6 +1367,24 @@
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "requires": {
         "iconv-lite": "^0.6.2"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
       }
     },
     "errno": {
@@ -1090,10 +1462,495 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "eslint": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
+      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.1",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-deprecation": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.2.1.tgz",
+      "integrity": "sha512-8KFAWPO3AvF0szxIh1ivRtHotd1fzxVOuNR3NI8dfCsQKgcxu9fAgEY+eTKvCRLAwwI8kaDDfImMt+498+EgRw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^2.19.2 || ^3.0.0",
+        "tslib": "^1.10.0",
+        "tsutils": "^3.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz",
+          "integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/types": "3.10.1",
+            "@typescript-eslint/typescript-estree": "3.10.1",
+            "eslint-scope": "^5.0.0",
+            "eslint-utils": "^2.0.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
+          "integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
+          "integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "3.10.1",
+            "@typescript-eslint/visitor-keys": "3.10.1",
+            "debug": "^4.1.1",
+            "glob": "^7.1.6",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
+          "integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
+      "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
+      "dev": true
+    },
+    "eslint-plugin-unused-imports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.1.tgz",
+      "integrity": "sha512-EApvRx9Q3XQI96Tg7xPPqY6OuOy95wWMXAtc8RrwdIRk9bv8vkJKwOVoE4HeWJOQhHeHcI8lUbOqmup/PxjfOw==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
@@ -1120,6 +1977,29 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "fast-glob": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
@@ -1134,6 +2014,18 @@
         "picomatch": "^2.2.1"
       }
     },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -1147,6 +2039,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
       }
     },
     "fill-range": {
@@ -1175,6 +2076,22 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
     },
     "foreach": {
       "version": "2.0.5",
@@ -1215,6 +2132,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "generic-names": {
       "version": "1.0.3",
@@ -1267,6 +2190,15 @@
       "integrity": "sha512-/pViTfifW+gBbh/RnlFYHINvELT9Znt+SYyDKAUL6uV6By019AK/s+i9XP4jSwq7lwP38Fd8HVeTxym3+hkwmQ==",
       "requires": {
         "stream-parser": "^0.3.1"
+      }
+    },
+    "get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
       }
     },
     "glob": {
@@ -1332,6 +2264,37 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
+    "globals": {
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
+      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "globby": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
@@ -1394,6 +2357,12 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
     "html-tags": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
@@ -1416,6 +2385,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
+    },
+    "husky": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-6.0.0.tgz",
+      "integrity": "sha512-SQS2gDTB7tBN486QSoKPKQItZw97BMOd+Kdb6ghfpBc0yXyzrddI0oDV5MkDAbuB4X2mO3/nj60TRMcYxwzZeQ==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.6.2",
@@ -1467,6 +2448,12 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true
+    },
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -1501,6 +2488,12 @@
       "requires": {
         "resolve-from": "^3.0.0"
       }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -1588,6 +2581,12 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
     "is-generator-function": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",
@@ -1634,6 +2633,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
+    },
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
@@ -1669,6 +2674,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "jest-worker": {
       "version": "27.0.0-next.5",
@@ -1714,6 +2725,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json5": {
@@ -1778,6 +2801,45 @@
         }
       }
     },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "loader-utils": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
@@ -1807,6 +2869,12 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -1824,12 +2892,27 @@
       "integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=",
       "dev": true
     },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "make-dir": {
@@ -1894,6 +2977,12 @@
       "dev": true,
       "optional": true
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -1930,10 +3019,29 @@
       "integrity": "sha512-1lM+BMLGuDfsdwf3rsgBSrxJwAZHFIrQ8YR61xIqdHo0uNKI9M52wNpHSrliZATJp51On6JD0AfRxd4YGSU0lw==",
       "dev": true
     },
+    "mri": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multimatch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+      "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      }
     },
     "nanoid": {
       "version": "3.1.22",
@@ -1954,6 +3062,12 @@
       "requires": {
         "querystring": "^0.2.0"
       }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "next": {
       "version": "10.2.0",
@@ -2195,6 +3309,26 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
       "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
     },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2205,6 +3339,15 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -2247,6 +3390,18 @@
         "object-keys": "^1.1.1"
       }
     },
+    "object.values": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
+      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "has": "^1.0.3"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2254,6 +3409,29 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "os-browserify": {
@@ -2296,6 +3474,23 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        }
+      }
     },
     "parse-asn1": {
       "version": "5.1.6",
@@ -2364,10 +3559,22 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
     "pbkdf2": {
@@ -2628,11 +3835,94 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+      "dev": true
+    },
+    "prettier-plugin-organize-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.0.0.tgz",
+      "integrity": "sha512-jPSE5sqFAu+lyKqwcN4zlSHaZmI6/3sJ2F+BkKn7iGCwNdPba1FPUJrx5bPzWnGyrQwGKQZYCuHgVQlCzohing==",
+      "dev": true
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
+    },
+    "pretty-quick": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.0.tgz",
+      "integrity": "sha512-DtxIxksaUWCgPFN7E1ZZk4+Aav3CCuRdhrDSFZENb404sYMtuo9Zka823F+Mgeyt8Zt3bUiCjFzzWYE9LYqkmQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "execa": "^4.0.0",
+        "find-up": "^4.1.0",
+        "ignore": "^5.1.4",
+        "mri": "^1.1.5",
+        "multimatch": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "process": {
       "version": "0.11.10",
@@ -2643,6 +3933,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "prop-types": {
       "version": "15.7.2",
@@ -2679,6 +3975,16 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -2787,6 +4093,95 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -2828,6 +4223,18 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "reserved-words": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
@@ -2861,6 +4268,15 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -2938,10 +4354,31 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
     "shell-quote": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -2950,6 +4387,49 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -2977,6 +4457,38 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
       "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
     "sprintf-js": {
@@ -3031,6 +4543,17 @@
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
+    "string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "string.prototype.trimend": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
@@ -3069,6 +4592,18 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "styled-jsx": {
@@ -3142,6 +4677,40 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.0.tgz",
+      "integrity": "sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.3.0.tgz",
+          "integrity": "sha512-RYE7B5An83d7eWnDR8kbdaIFqmKCNsP16ay1hDbJEU+sa0e3H9SebskCt0Uufem6cfAVu7Col6ubcn/W+Sm8/Q==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
       }
     },
     "tailwindcss": {
@@ -3230,6 +4799,12 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -3292,10 +4867,28 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tty-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw=="
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
     },
     "type-fest": {
       "version": "0.7.1",
@@ -3379,6 +4972,15 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
@@ -3432,6 +5034,22 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "vm-browserify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -3461,6 +5079,15 @@
         "webidl-conversions": "^4.0.2"
       }
     },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "which-boxed-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
@@ -3487,6 +5114,12 @@
         "is-typed-array": "^1.1.3"
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3497,6 +5130,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "lint": "eslint \"{components,pages}/**/*.{ts,tsx}\" --max-warnings 0",
+    "format": "prettier \"{components,pages}/**/*.{ts,tsx}\" -w"
   },
   "dependencies": {
     "@headlessui/react": "^1.1.1",
@@ -18,10 +20,28 @@
   "devDependencies": {
     "@tailwindcss/aspect-ratio": "^0.2.0",
     "@types/react": "^17.0.4",
+    "@typescript-eslint/eslint-plugin": "^4.23.0",
+    "@typescript-eslint/parser": "^4.23.0",
     "autoprefixer": "^10.2.5",
+    "eslint": "^7.26.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-deprecation": "^1.2.1",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-unused-imports": "^1.1.1",
+    "husky": "^6.0.0",
     "postcss": "^8.2.13",
+    "prettier": "^2.3.0",
+    "prettier-plugin-organize-imports": "^2.0.0",
+    "pretty-quick": "^3.1.0",
     "tailwindcss": "^2.1.2",
     "typescript": "^4.2.4",
     "typescript-plugin-css-modules": "^3.2.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,10 @@
-import Navigation from "../components/layouts/navigation/navigation";
-import Footer from "../components/layouts/footer/footer";
-import ScrollButton from "../components/scroll-button/scroll-button";
-import "../styles/globals.css";
+import { AppProps } from 'next/app'
+import Footer from '../components/layouts/footer/footer'
+import Navigation from '../components/layouts/navigation/navigation'
+import ScrollButton from '../components/scroll-button/scroll-button'
+import '../styles/globals.css'
 
-function MyApp({ Component, pageProps }) {
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   return (
     <>
       <div className="fixed bg-radial-gradient w-full h-full"></div>
@@ -12,7 +13,7 @@ function MyApp({ Component, pageProps }) {
       <Footer />
       <ScrollButton />
     </>
-  );
+  )
 }
 
-export default MyApp;
+export default MyApp

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,56 +1,56 @@
-import Head from "next/head";
-import Hero from "../components/templates/hero/hero";
-import Information from "../components/templates/information/information";
-import Features from "../components/templates/features/features";
-import Ecosystem from "../components/templates/ecosystem/ecosystem";
-import Investor from "../components/templates/inverstor/investor";
-import Roadmap from "../components/templates/roadmap/roadmap";
-import { IMember } from "../components/templates/hero/types";
+import Head from 'next/head'
+import Ecosystem from '../components/templates/ecosystem/ecosystem'
+import Features from '../components/templates/features/features'
+import Hero from '../components/templates/hero/hero'
+import { IMember } from '../components/templates/hero/types'
+import Information from '../components/templates/information/information'
+import Investor from '../components/templates/inverstor/investor'
+import Roadmap from '../components/templates/roadmap/roadmap'
 
 const members: IMember[] = [
   {
-    name: "216k155",
-    role: "Co-founder | Marketing Manager",
-    imageUrl: "/members/216k155.png",
+    name: '216k155',
+    role: 'Co-founder | Marketing Manager',
+    imageUrl: '/members/216k155.png',
   },
   {
-    name: "Jun",
-    role: "Co-founder | Strateger",
-    imageUrl: "/members/jun.png",
+    name: 'Jun',
+    role: 'Co-founder | Strateger',
+    imageUrl: '/members/jun.png',
   },
   {
-    name: "Andre",
-    role: "Co-founder | Technical Manager",
-    imageUrl: "/members/andre.png",
+    name: 'Andre',
+    role: 'Co-founder | Technical Manager',
+    imageUrl: '/members/andre.png',
   },
   {
-    name: "Akira",
-    role: "Co-founder | Project Manager",
-    imageUrl: "/members/akira.png",
+    name: 'Akira',
+    role: 'Co-founder | Project Manager',
+    imageUrl: '/members/akira.png',
   },
   {
-    name: "Evil",
-    role: "Co-founder | Design manager",
-    imageUrl: "/members/evil.png",
+    name: 'Evil',
+    role: 'Co-founder | Design manager',
+    imageUrl: '/members/evil.png',
   },
   {
-    name: "Eugen",
-    role: "Dude | Technical Advisor",
-    imageUrl: "/members/eugen.png",
+    name: 'Eugen',
+    role: 'Dude | Technical Advisor',
+    imageUrl: '/members/eugen.png',
   },
   {
-    name: "Adidust.eth",
-    role: "Dude | Marketing Advisor",
-    imageUrl: "/members/adidust.eth.png",
+    name: 'Adidust.eth',
+    role: 'Dude | Marketing Advisor',
+    imageUrl: '/members/adidust.eth.png',
   },
   {
-    name: "Ahmed",
-    role: "Dude | Frontend Advisor",
-    imageUrl: "/members/ahmed.png",
+    name: 'Ahmed',
+    role: 'Dude | Frontend Advisor',
+    imageUrl: '/members/ahmed.png',
   },
-];
+]
 
-export default function Home() {
+export default function Home(): JSX.Element {
   return (
     <>
       <Head>
@@ -70,5 +70,5 @@ export default function Home() {
       <Investor />
       <Roadmap />
     </>
-  );
+  )
 }


### PR DESCRIPTION
Add prettier for formatting and eslint with many strict rules for lint. This ensures that the codebase stays exactly the same and not related to any developer preferences.

Checks of format and errors are done during the commit with the husky library or can be done manually with

- `npm run format`
- `npm run lint`